### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,8 @@ concurrency:
   group: lint-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
 jobs:
   lint:
     name: Lint Code


### PR DESCRIPTION
Potential fix for [https://github.com/TRC-Loop/CronDNS/security/code-scanning/1](https://github.com/TRC-Loop/CronDNS/security/code-scanning/1)

To fix this issue, we need to explicitly define the `permissions` key either at the root of the workflow or under each job (the latter only if jobs need different permissions). In this case, the workflow runs only lint checks and does not require any write permissions; the minimum token permission is read access to repository contents. Therefore, adding `permissions: contents: read` is the best fix. This should be placed at the workflow root (before `jobs:`), ensuring all jobs have restricted permissions unless specifically overridden. This change needs to be made in `.github/workflows/lint.yml`, above the `jobs:` field.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
