### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,4 +1,6 @@
 name: Build Docker on Release
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/TRC-Loop/CronDNS/security/code-scanning/4](https://github.com/TRC-Loop/CronDNS/security/code-scanning/4)

To fix the problem, add a `permissions` key to the workflow. This can be placed at the root (preferred for most simple workflows) so it applies to all jobs, unless jobs require differing levels of permission. For this workflow, only reading contents is required, as all the steps interact with external services or build locally. The permissions block should be inserted near the top level, preferably right after the workflow `name` field and before `on`.

Steps:
- In the `.github/workflows/docker-release.yml` file, add the following block:
  ```yaml
  permissions:
    contents: read
  ```
- Place this immediately after the `name: Build Docker on Release` line, before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
